### PR TITLE
Add Power ppc64le support  on 2024-1-8

### DIFF
--- a/rpm/build_all.sh
+++ b/rpm/build_all.sh
@@ -62,6 +62,8 @@ if [ "${OS_ARCH}x" = "ppc64lex" ]; then
         scp devdeps-openssl-static.1.1.1u.spec devdeps-openssl-static.spec
     fi
     bash devdeps-openssl-static-build.1.1.1u.sh
+
+    bash devdeps-rocksdb-build-with-system-gcc.sh
 fi
 
 

--- a/rpm/build_all.sh
+++ b/rpm/build_all.sh
@@ -44,3 +44,24 @@ if [ ${NEED_BUILD_COMPILER} = 1 ]; then
     bash obdevtools-gcc9-build.sh
 fi
 
+if [ "${OS_ARCH}x" = "ppc64lex" ]; then
+    ##backup local spec file first
+    if ! grep 11.1.0 obdevtools-llvm.spec |grep -i version > /dev/null
+    then
+        scp  obdevtools-llvm.spec obdevtools-llvm.11.0.1.spec
+        scp  obdevtools-llvm.11.1.0.spec obdevtools-llvm.spec
+    fi
+    bash obdevtools-llvm-build-11.1.0.sh
+
+    bash devdeps-zlib-shared-build.sh
+
+    ##backup local spec file first
+    if ! grep 1.1.1u devdeps-openssl-static.spec |grep -i version > /dev/null
+    then
+        scp devdeps-openssl-static.spec devdeps-openssl-static.1.0.1e.spec 
+        scp devdeps-openssl-static.1.1.1u.spec devdeps-openssl-static.spec
+    fi
+    bash devdeps-openssl-static-build.1.1.1u.sh
+fi
+
+

--- a/rpm/devdeps-cos-c-sdk.spec
+++ b/rpm/devdeps-cos-c-sdk.spec
@@ -62,7 +62,8 @@ make install
 
 #step 5: install minixml
 cd ../mxml-3.3
-./configure --prefix=/usr/local/
+CFLAG="-O2" \
+./configure --prefix=/usr/local
 make
 make install
 

--- a/rpm/devdeps-icu.spec
+++ b/rpm/devdeps-icu.spec
@@ -48,6 +48,9 @@ make install
 # install files
 cp -r ${tmp_install_dir}/lib/*.a $RPM_BUILD_ROOT/%{_prefix}/lib
 cp -r ${tmp_install_dir}/include/* $RPM_BUILD_ROOT/%{_prefix}/include/%{_product_prefix}
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}/include/%{_product_prefix}/i18n/unicode
+cp ../icu4c/source/i18n/unicode/*.h $RPM_BUILD_ROOT/%{_prefix}/include/%{_product_prefix}/i18n/unicode/
+
 
 # package infomation
 %files 

--- a/rpm/devdeps-isa-l-static.spec
+++ b/rpm/devdeps-isa-l-static.spec
@@ -26,6 +26,12 @@ ISA-L is a collection of optimized low-level functions targeting storage applica
 
 %build
 
+BUILD_OPTION=''
+OS_ARCH="$(uname -m)"
+if [ "${OS_ARCH}x" = "ppc64lex" ]; then
+    BUILD_OPTION='--build=ppc64le'
+fi
+
 rm -rf %{_tmppath}
 mkdir -p %{_tmppath}
 cd $OLDPWD/../
@@ -33,7 +39,7 @@ rm -rf %{_src}
 tar -xf %{_src}.tar.gz
 cd %{_src}
 ./autogen.sh
-./configure --enable-static --with-pic=yes --disable-shared --prefix=%{_tmppath}
+./configure ${BUILD_OPTION} --enable-static --with-pic=yes --disable-shared --prefix=%{_tmppath}
 CPU_CORES=`grep -c ^processor /proc/cpuinfo`
 make -j${CPU_CORES};
 make install

--- a/rpm/devdeps-libcurl-static.spec
+++ b/rpm/devdeps-libcurl-static.spec
@@ -40,6 +40,8 @@ if [ "${OS_ARCH}x" = "sw_64x" ]; then
     BUILD_OPTION='--build=sw_64-unknown-linux-gnu'
 elif [ "${OS_ARCH}x" = "aarch64x" ]; then
     BUILD_OPTION='--build=aarch64-unknown-linux-gnu'
+elif [ "${OS_ARCH}x" = "ppc64lex" ]; then
+    BUILD_OPTION='--build=ppc64le'
 fi
 
 ./configure --prefix=%{_tmppath} --without-libssh2 --without-nss --disable-ftp --disable-ldap --disable-ldaps --without-cyassl \

--- a/rpm/devdeps-mariadb-connector-c.spec
+++ b/rpm/devdeps-mariadb-connector-c.spec
@@ -26,6 +26,7 @@ mkdir -p %{_tmppath}
 cd $OLDPWD/../
 rm -rf %{_src}
 tar -xf %{_src}.tar.gz
+sed -i 's/END()/ENDIF()/g' mariadb-connector-c-3.1.12/cmake/ConnectorName.cmake
 cd %{_src}
 mkdir -p build-rpm;
 cd build-rpm

--- a/rpm/devdeps-openssl-static-build.1.1.1u.sh
+++ b/rpm/devdeps-openssl-static-build.1.1.1u.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+CUR_DIR=$(dirname $(readlink -f "$0"))
+ROOT_DIR=$CUR_DIR/../
+PROJECT_DIR=${1:-"$CUR_DIR"}
+PROJECT_NAME=${2:-"devdeps-openssl-static"}
+VERSION=${3:-"1.1.1u"}
+RELEASE=${4:-"1"}
+
+# check source code
+if [[ -z `find $ROOT_DIR -maxdepth 1 -regex ".*/openssl-$VERSION.*[tar|gz|bz2|xz|zip]$"` ]]; then
+    echo "Download source code"
+    wget --no-check-certificate https://ftp.openssl.org/source/old/1.1.1/openssl-1.1.1u.tar.gz -P $ROOT_DIR
+fi
+
+cd $CUR_DIR
+bash $CUR_DIR/rpmbuild.sh $PROJECT_DIR $PROJECT_NAME $VERSION $RELEASE

--- a/rpm/devdeps-openssl-static.1.1.1u.spec
+++ b/rpm/devdeps-openssl-static.1.1.1u.spec
@@ -1,0 +1,62 @@
+Name: devdeps-openssl-static
+Version: 1.1.1u
+Release: %(echo $RELEASE)%{?dist}
+
+Summary: OpenSSL is a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.
+Url: https://www.openssl.org/
+Group: oceanbase-devel/dependencies
+License: OpenSSL
+AutoReqProv:no
+
+%undefine _missing_build_ids_terminate_build
+%define _build_id_links compat
+
+# disable check-buildroot
+%define __arch_install_post %{nil}
+
+%define _prefix /usr/local/oceanbase/deps/devel
+%define _src openssl-%{version}
+
+%define debug_package %{nil}
+%define __strip /bin/true
+
+%define _buliddir %{_topdir}/BUILD
+%define _tmppath %{_buliddir}/_tmp
+
+%description
+OpenSSL is a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. 
+It is also a general-purpose cryptography library. For more information about the team and community around the project, or to start making your own contributions, 
+start with the community page. To get the latest news, download the source, and so on, please see the sidebar or the buttons at the top of every page.
+
+%build
+
+# incompat with openssl config. unset it here
+unset RELEASE
+rm -rf %{_tmppath}
+mkdir -p %{_tmppath}
+cd $OLDPWD/../
+rm -rf %{_src}
+tar -xf %{_src}.tar.gz
+cd %{_src}
+#make dclean
+./config --prefix=%{_prefix} -fPIC no-shared --openssldir=%{_prefix}
+make depend
+make all
+make install_sw
+
+%install
+
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}
+cp -r %{_prefix}/lib %{_prefix}/include $RPM_BUILD_ROOT/%{_prefix}
+
+%files 
+
+%defattr(-,root,root)
+%{_prefix}
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%changelog
+* Fri Mar 26 2021 oceanbase
+- add spec of cmake

--- a/rpm/devdeps-rocksdb-build-with-system-gcc.sh
+++ b/rpm/devdeps-rocksdb-build-with-system-gcc.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+CUR_DIR=$(dirname $(readlink -f "$0"))
+ROOT_DIR=$CUR_DIR/../
+PROJECT_DIR=${1:-"$CUR_DIR"}
+PROJECT_NAME=${2:-"devdeps-rocksdb"}
+VERSION=${3:-"6.22.1"}
+RELEASE=${4:-"1"}
+
+# check source code
+if [[ -z `find $ROOT_DIR -maxdepth 1 -regex ".*/rocksdb-$VERSION.*[tar|gz|bz2|xz|zip]$"` ]]; then
+    for cnt in {1..6}
+    do
+        echo "Download source code with retry cnt = "$cnt
+        wget --no-check-certificate https://mirror.ghproxy.com/https://github.com/facebook/rocksdb/archive/refs/tags/v6.22.1.tar.gz -O $ROOT_DIR/rocksdb-$VERSION.tar.gz
+        if [[ $? == 0 ]];then
+            break
+        fi
+    done
+fi
+
+# prepare building environment
+# please prepare environment yourself if the following solution does not work for you.
+OS_RELEASE=$(grep -Po '(?<=release )\d' /etc/redhat-release)
+
+echo "Use obdevtools-gcc9 may raise such ld.lld: error: expected a 'ld' for got-indirect to toc-relative relaxing"
+echo "So build with gcc-toolset-11 gcc on ppc64le"
+
+source /opt/rh/gcc-toolset-11/enable
+
+cd $CUR_DIR
+bash $CUR_DIR/rpmbuild.sh $PROJECT_DIR $PROJECT_NAME $VERSION $RELEASE

--- a/rpm/devdeps-zlib-shared-build.sh
+++ b/rpm/devdeps-zlib-shared-build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+CUR_DIR=$(dirname $(readlink -f "$0"))
+ROOT_DIR=$CUR_DIR/../
+PROJECT_DIR=${1:-"$CUR_DIR"}
+PROJECT_NAME=${2:-"devdeps-zlib-shared"}
+VERSION=${3:-"1.2.7"}
+RELEASE=${4:-"1"}
+
+# check source code
+if [[ -z `find $ROOT_DIR -maxdepth 1 -regex ".*/curl-$VERSION.*[tar|gz|bz2|xz|zip]$"` ]]; then
+    echo "Download source code"
+    wget --no-check-certificate https://codeload.github.com/madler/zlib/tar.gz/refs/tags/v1.2.7 -O zlib-1.2.7.tar.gz -P $ROOT_DIR
+fi
+
+cd $CUR_DIR
+bash $CUR_DIR/rpmbuild.sh $PROJECT_DIR $PROJECT_NAME $VERSION $RELEASE

--- a/rpm/devdeps-zlib-shared.spec
+++ b/rpm/devdeps-zlib-shared.spec
@@ -1,0 +1,62 @@
+Name: devdeps-zlib-shared
+Version: 1.2.7
+Release: %(echo $RELEASE)%{?dist}
+Url: https://curl.se/
+Summary: zlib is a general purpose data compression library.
+
+Group: oceanbase-devel/dependencies
+License: MIT
+
+%undefine _missing_build_ids_terminate_build
+%define _build_id_links compat
+
+# disable check-buildroot
+%define __arch_install_post %{nil}
+
+%define _prefix /usr/local/oceanbase/deps/devel
+%define _src zlib-%{version}
+
+%define debug_package %{nil}
+%define __strip /bin/true
+
+%define _buliddir %{_topdir}/BUILD
+%define _tmppath %{_buliddir}/_tmp
+
+%description
+zlib is a general purpose data compression library.
+
+%build
+
+rm -rf %{_tmppath}
+mkdir -p %{_tmppath}
+cd $OLDPWD/../
+
+cd rpm
+
+rm -rf %{_src}
+
+tar -zxvf %{_src}.tar.gz
+cd %{_src}
+
+CFLAGS='-fPIC -O3' SFLAGS='-shared' ./configure --prefix=%{_tmppath} --shared 
+
+CPU_CORES=`grep -c ^processor /proc/cpuinfo`
+make -j${CPU_CORES};
+make install
+
+%install
+
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}
+cp -r %{_tmppath}/lib %{_tmppath}/include $RPM_BUILD_ROOT/%{_prefix}
+
+%files 
+
+%defattr(-,root,root)
+%{_prefix}
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%changelog
+* Tue Sep 29 2022 oceanbase
+- add spec of zlib

--- a/rpm/obdevtools-bison.spec
+++ b/rpm/obdevtools-bison.spec
@@ -35,6 +35,8 @@ if [ "${OS_ARCH}x" = "sw_64x" ]; then
     BUILD_OPTION='--build=sw_64-unknown-linux-gnu'
 elif [ "${OS_ARCH}x" = "aarch64x" ]; then
     BUILD_OPTION='--build=aarch64-unknown-linux-gnu'
+elif [ "${OS_ARCH}x" = "ppc64lex" ]; then
+    BUILD_OPTION='--build=ppc64le'
 fi
 
 ./configure --prefix=${RPM_BUILD_ROOT}/%{_prefix} ${BUILD_OPTION}

--- a/rpm/obdevtools-flex.spec
+++ b/rpm/obdevtools-flex.spec
@@ -33,6 +33,8 @@ if [ "${OS_ARCH}x" = "sw_64x" ]; then
     BUILD_OPTION='--build=sw_64-unknown-linux-gnu'
 elif [ "${OS_ARCH}x" = "aarch64x" ]; then
     BUILD_OPTION='--build=aarch64-unknown-linux-gnu'
+elif [ "${OS_ARCH}x" = "ppc64lex" ]; then
+    BUILD_OPTION='--build=ppc64le'
 fi
 
 

--- a/rpm/obdevtools-llvm-build-11.1.0.sh
+++ b/rpm/obdevtools-llvm-build-11.1.0.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+CUR_DIR=$(dirname $(readlink -f "$0"))
+ROOT_DIR=$CUR_DIR/../
+PROJECT_DIR=${1:-"$CUR_DIR"}
+PROJECT_NAME=${2:-"obdevtools-llvm"}
+VERSION=${3:-"11.1.0"}
+RELEASE=${4:-"1"}
+
+# check source code
+if [[ -z `find $ROOT_DIR -maxdepth 1 -regex ".*/llvm-$VERSION.*[tar|gz|bz2|xz|zip]$"` ]]; then
+    echo "Download source code"
+    wget https://mirror.ghproxy.com/https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/llvm-11.1.0.src.tar.xz -P $ROOT_DIR --no-check-certificate
+    wget https://mirror.ghproxy.com/https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/lld-11.1.0.src.tar.xz -P $ROOT_DIR --no-check-certificate
+    wget https://mirror.ghproxy.com/https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/clang-11.1.0.src.tar.xz -P $ROOT_DIR --no-check-certificate
+    wget https://mirror.ghproxy.com/https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/compiler-rt-11.1.0.src.tar.xz -P $ROOT_DIR --no-check-certificate
+fi
+
+# prepare building environment
+OS_RELEASE=$(grep -Po '(?<=release )\d' /etc/redhat-release)
+if [ "$(uname -m)" == "ppc64le" ];then
+    echo "Now install obdevtools-cmake and obdevtools-gcc manually!"
+else
+    wget http://mirrors.aliyun.com/oceanbase/OceanBase.repo -P /etc/yum.repos.d/
+    yum install obdevtools-cmake-3.22.1 -y
+    yum install obdevtools-gcc9-9.3.0 -y
+fi
+
+export PATH=/usr/local/oceanbase/devtools/bin:$PATH
+
+ln -sf /usr/local/oceanbase/devtools/bin/g++  /usr/bin/c++
+ln -sf /usr/local/oceanbase/devtools/bin/gcc  /usr/bin/cc
+
+cd $CUR_DIR
+bash $CUR_DIR/rpmbuild.sh $PROJECT_DIR $PROJECT_NAME $VERSION $RELEASE

--- a/rpm/obdevtools-llvm.11.1.0.spec
+++ b/rpm/obdevtools-llvm.11.1.0.spec
@@ -39,21 +39,6 @@ tar xf %{_lld_src}.tar.xz
 tar xf %{_clang_src}.tar.xz
 tar xf %{_compiler_rt_src}.tar.xz
 
-# LLVM_ENABLE_PROJECTS requires putting module source code directory and llvm source code directory into the same directory.
-# llvm_src_dir/
-# ├── clang
-# └── llvm
-rm -rf $source_dir/llvm_src_dir
-mkdir -p $source_dir/llvm_src_dir
-mv -f %{_llvm_src} $source_dir/llvm_src_dir/llvm
-sed -i 's/#include <vector>/#include <vector>\n#include <limits>/g' $source_dir/llvm_src_dir/llvm/utils/benchmark/src/benchmark_register.h
-mv -f %{_clang_src} $source_dir/llvm_src_dir/clang
-mv -f %{_compiler_rt_src} $source_dir/llvm_src_dir/compiler-rt
-mv -f %{_lld_src} $source_dir/llvm_src_dir/lld
-cd $source_dir/llvm_src_dir
-mkdir -p build-rpm
-cd build-rpm
-
 arch=`uname -p`
 if [[ x"$arch" == x"x86_64" ]]; then
     echo "Build arch: x86"
@@ -68,6 +53,23 @@ else
     echo "Unknown arch"
     exit 1
 fi
+
+# LLVM_ENABLE_PROJECTS requires putting module source code directory and llvm source code directory into the same directory.
+# llvm_src_dir/
+# ├── clang
+# └── llvm
+rm -rf $source_dir/llvm_src_dir
+mkdir -p $source_dir/llvm_src_dir
+mv -f %{_llvm_src} $source_dir/llvm_src_dir/llvm
+if [[ x"$arch" == x"ppc64le" ]]; then
+sed -i 's/#include <vector>/#include <vector>\n#include <limits>/g' $source_dir/llvm_src_dir/llvm/utils/benchmark/src/benchmark_register.h
+fi
+mv -f %{_clang_src} $source_dir/llvm_src_dir/clang
+mv -f %{_compiler_rt_src} $source_dir/llvm_src_dir/compiler-rt
+mv -f %{_lld_src} $source_dir/llvm_src_dir/lld
+cd $source_dir/llvm_src_dir
+mkdir -p build-rpm
+cd build-rpm
 
 cmake ../llvm  \
     -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" \
@@ -102,7 +104,9 @@ tar xf %{_compiler_rt_src}.tar.xz
 rm -rf $source_dir/llvm_src_dir
 mkdir -p $source_dir/llvm_src_dir
 mv -f %{_llvm_src} $source_dir/llvm_src_dir/llvm
+if [[ x"$arch" == x"ppc64le" ]]; then
 sed -i 's/#include <vector>/#include <vector>\n#include <limits>/g' $source_dir/llvm_src_dir/llvm/utils/benchmark/src/benchmark_register.h
+fi
 mv -f %{_clang_src} $source_dir/llvm_src_dir/clang
 mv -f %{_compiler_rt_src} $source_dir/llvm_src_dir/compiler-rt
 mv -f %{_lld_src} $source_dir/llvm_src_dir/lld

--- a/rpm/obdevtools-llvm.11.1.0.spec
+++ b/rpm/obdevtools-llvm.11.1.0.spec
@@ -46,6 +46,7 @@ tar xf %{_compiler_rt_src}.tar.xz
 rm -rf $source_dir/llvm_src_dir
 mkdir -p $source_dir/llvm_src_dir
 mv -f %{_llvm_src} $source_dir/llvm_src_dir/llvm
+sed -i 's/#include <vector>/#include <vector>\n#include <limits>/g' $source_dir/llvm_src_dir/llvm/utils/benchmark/src/benchmark_register.h
 mv -f %{_clang_src} $source_dir/llvm_src_dir/clang
 mv -f %{_compiler_rt_src} $source_dir/llvm_src_dir/compiler-rt
 mv -f %{_lld_src} $source_dir/llvm_src_dir/lld
@@ -101,6 +102,7 @@ tar xf %{_compiler_rt_src}.tar.xz
 rm -rf $source_dir/llvm_src_dir
 mkdir -p $source_dir/llvm_src_dir
 mv -f %{_llvm_src} $source_dir/llvm_src_dir/llvm
+sed -i 's/#include <vector>/#include <vector>\n#include <limits>/g' $source_dir/llvm_src_dir/llvm/utils/benchmark/src/benchmark_register.h
 mv -f %{_clang_src} $source_dir/llvm_src_dir/clang
 mv -f %{_compiler_rt_src} $source_dir/llvm_src_dir/compiler-rt
 mv -f %{_lld_src} $source_dir/llvm_src_dir/lld

--- a/rpm/obdevtools-llvm.11.1.0.spec
+++ b/rpm/obdevtools-llvm.11.1.0.spec
@@ -1,5 +1,5 @@
 Name: obdevtools-llvm
-Version: 11.0.1
+Version: 11.1.0
 Release: %(echo $RELEASE)%{?dist}
 
 Summary: The LLVM Project is a collection of modular and reusable compiler and toolchain technologies.
@@ -124,8 +124,8 @@ make -j${CPU_CORES};
 make install;
 
 # step3: replace asan debuginfo lib
-rm -rf %{_rel_dir}/lib/clang/11.0.1/lib/linux
-cp -rf %{_relwithdebinfo_dir}/lib/clang/11.0.1/lib/linux %{_rel_dir}/lib/clang/11.0.1/lib/
+rm -rf %{_rel_dir}/lib/clang/11.1.0/lib/linux
+cp -rf %{_relwithdebinfo_dir}/lib/clang/11.1.0/lib/linux %{_rel_dir}/lib/clang/11.1.0/lib/
 
 %install
 # create dirs


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
**Changed files:**
file: rpm/obdevtools-llvm.spec ## add ppc64le support:
elif [[ x"$arch" == x"ppc64le" ]]; then
    echo "Build arch: ppc64le"
    arch=PowerPC
    
file: rpm/devdeps-mariadb-connector-c.spec  ## mariadb-connector-c-3.1.12 cmake template issue, END() should beENDIF()
sed -i 's/END()/ENDIF()/g' mariadb-connector-c-3.1.12/cmake/ConnectorName.cmake

file: rpm/obdevtools-flex.spec   ## add ppc64le support:
elif [ "${OS_ARCH}x" = "ppc64lex" ]; then
    BUILD_OPTION='--build=ppc64le'


file: rpm/obdevtools-bison.spec   ## add ppc64le support:
elif [ "${OS_ARCH}x" = "ppc64lex" ]; then
    BUILD_OPTION='--build=ppc64le'


file: rpm/devdeps-libcurl-static.spec   ## add ppc64le support:
elif [ "${OS_ARCH}x" = "ppc64lex" ]; then
    BUILD_OPTION='--build=ppc64le'

file: rpm/devdeps-isa-l-static.spec   ##add ppc64le support:
BUILD_OPTION=''
OS_ARCH="$(uname -m)"
if [ "${OS_ARCH}x" = "ppc64lex" ]; then
    BUILD_OPTION='--build=ppc64le'
fi

./configure ${BUILD_OPTION} --enable-static --with-pic=yes --disable-shared --prefix=%{_tmppath}

file: rpm/devdeps-icu.spec   ## add necessary .h files to rpm
mkdir -p $RPM_BUILD_ROOT/%{_prefix}/include/%{_product_prefix}/i18n/unicode
cp ../icu4c/source/i18n/unicode/*.h $RPM_BUILD_ROOT/%{_prefix}/include/%{_product_prefix}/i18n/unicode/

file: rpm/devdeps-cos-c-sdk.spec.patch   ##add CFLAG="-O2" \ to avoid such issue: ld.lld: error: undefined symbol: _restfpr_31
CFLAG="-O2" \

file: rpm/build_all.sh ##build llvm 11.1.0, zlib_shard, openssl-static.1.1.1u for ppc64le
if [ "${OS_ARCH}x" = "ppc64lex" ]; then
    ##backup local spec file first
    if ! grep 11.1.0 obdevtools-llvm.spec |grep -i version > /dev/null
    then
        scp  obdevtools-llvm.spec obdevtools-llvm.11.0.1.spec
        scp  obdevtools-llvm.11.1.0.spec obdevtools-llvm.spec
    fi
    bash obdevtools-llvm-build-11.1.0.sh

    bash devdeps-zlib-shared-build.sh

    ##backup local spec file first
    if ! grep 1.1.1u devdeps-openssl-static.spec |grep -i version > /dev/null
    then
        scp devdeps-openssl-static.spec devdeps-openssl-static.1.0.1e.spec
        scp devdeps-openssl-static.1.1.1u.spec devdeps-openssl-static.spec
    fi
    bash devdeps-openssl-static-build.1.1.1u.sh

    bash devdeps-rocksdb-build-with-system-gcc.sh
fi


**Add Files:** 
## 1. Now use LLVM 11.1.0 to build oceanbase
obdevtools-llvm-build-11.1.0.sh obdevtools-llvm.11.1.0.spec  
## 2. shared zlib is needed to build oceanbase
devdeps-zlib-shared-build.sh devdeps-zlib-shared.spec
## 3. upgrade openssl to 1.1.1u
devdeps-openssl-static-build.1.1.1u.sh  devdeps-openssl-static.1.1.1u.spec 
## 4. devdeps-rocksdb-build-with-system-gcc.sh

**Shell Scripts:** 


## Need to upload rpms onto http://mirrors.aliyun.com/oceanbase/community/stable/el/$releasever/$basearch/ and http://mirrors.aliyun.com/oceanbase/development-kit/el/$releasever/$basearch/

file: rpm/devdeps-cos-c-sdk-build.sh  ## depends on: obdevtools-cmake
file: rpm/devdeps-icu-build.sh        ## depends on: obdevtools-gcc9  obdevtools-cmake
file: rpm/devdeps-oss-c-sdk-build.sh  ## depends on: devdeps-mxml devdeps-apr
file: rpm/devdeps-s2geometry-build.sh ## depends on: obdevtools-gcc obdevtools-cmake devdeps-openssl-static
file: rpm/obdevtools-llvm-build.sh    ## depends on: obdevtools-gcc9  obdevtools-cmake



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
